### PR TITLE
enhancing the example

### DIFF
--- a/example_with_custom_rewrite.py
+++ b/example_with_custom_rewrite.py
@@ -1,0 +1,38 @@
+import llvmlite
+import numpy as np  # noqa: E402
+
+llvmlite.opaque_pointers_enabled = True
+
+from mlir_egglog import kernel  # noqa: E402
+from mlir_egglog.term_ir import Term, Sin, Cos, Mul, Add 
+from egglog import rewrite, ruleset
+from mlir_egglog.basic_simplify import basic_math
+
+# A rewrite rule
+@ruleset
+def trig_double_angle(a: Term):
+    sin_a = Sin(a)
+    cos_a = Cos(a)
+    mul1 = Mul(sin_a, cos_a)
+    mul2 = Mul(cos_a, sin_a)
+
+    # sin(a)*cos(a) + cos(a)*sin(a) -> 2 * sin(a)*cos(a)
+    yield rewrite(Add(mul1, mul2)).to(
+        Mul(Term.lit_f32(2.0), mul1)
+    )
+
+# Apply the rewrites
+@kernel("float32(float32)", rewrites = (basic_math, trig_double_angle))
+def fn(a):
+    return np.sin(a) * np.cos(a) + np.cos(a) * np.sin(a)
+
+def ref_fn(a):
+    return np.sin(a) * np.cos(a) + np.cos(a) * np.sin(a)
+
+# Observe that the output LLVM IR is optimized. 
+out = fn(np.array([1.0], dtype=np.float32))
+ref = ref_fn(np.array([1.0], dtype=np.float32))
+print(out)
+print(ref)
+
+assert np.allclose(out, ref)

--- a/src/mlir_egglog/egglog_optimizer.py
+++ b/src/mlir_egglog/egglog_optimizer.py
@@ -47,12 +47,11 @@ def extract(ast: Expr, rules: tuple[RewriteOrRule | Ruleset, ...], debug=False) 
 def compile(
     fn: FunctionType, rewrites: tuple[RewriteOrRule | Ruleset, ...] = OPTS, debug=True
 ) -> str:
-    # Convert np functions accordinging to the namespace map
+    # Convert np functions according to the namespace map
     exprtree = interpret(fn, {"np": ns})
     extracted = extract(exprtree, rewrites, debug)
 
     # Get the argument spec
     argspec = inspect.signature(fn)
     params = ",".join(map(str, argspec.parameters))
-
     return convert_term_to_mlir(extracted, params)


### PR DESCRIPTION
Thanks for the repo, its a great starting point for integrating Egglog and MLIR. 

The example.py script was a bit confusing to me because the final LLVM IR had the optimization (O2 magic, perhaps) but the generated Egglog IR/MLIR did not. I created a simple rewrite to push the optimization further up.  

Hoping the website is back up soon!